### PR TITLE
Add workflow for publishing to GitHub Packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,21 @@
+name: Publish package to GitHub Packages
+on:
+  push:
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+*
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Publish package
+        run: mvn --batch-mode deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# serilogj [![Bintray](https://img.shields.io/bintray/v/serilogj/serilogj/serilogj.svg)](https://bintray.com/serilogj/serilogj/serilogj)
+# serilogj
 
 _serilogj_ is a structured logger that is an almost 1-on-1 code conversion of [Serilog for .NET](https://serilog.net). Not everything has been converted, but the a lot of functionality is included in this conversion. Using this in combination with [Seq](https://getseq.net) will make searching through log files a lot easier.
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.serilogj.serilogj</groupId>
+  <groupId>org.serilogj</groupId>
   <artifactId>serilogj</artifactId>
   <version>0.6.1</version>
   <name>serilogj</name>

--- a/pom.xml
+++ b/pom.xml
@@ -56,8 +56,9 @@
 
   <distributionManagement>
     <repository>
-      <id>serilogj</id>
-      <url>https://api.bintray.com/maven/serilogj/serilogj/serilogj/;publish=1</url>
+      <id>github</id>
+      <name>GitHub Packages</name>
+      <url>https://maven.pkg.github.com/serilogj/serilogj</url>
     </repository>
   </distributionManagement>
 </project>


### PR DESCRIPTION
Bintray has been deprecated. Publishing to GitHub Packages is a quick & easy replacement.

(Please create tag v0.6.1 after merging to trigger the workflow.)